### PR TITLE
Fix guide text in hero banner

### DIFF
--- a/features/Home/components/HeroBanner/HeroBanner.js
+++ b/features/Home/components/HeroBanner/HeroBanner.js
@@ -41,7 +41,7 @@ const HeroBanner = () => {
               lineHeight="shorter"
               marginBottom="1.5rem"
             >
-              Download our new <strong>Property Buying Guide </strong>
+              Download our new <strong>Home Buying Guide </strong>
               today ...
             </Text>
             <Text fontSize={{ base: "lg", sm: "2xl" }}>


### PR DESCRIPTION
## Summary
- update hero banner to reference *Home Buying Guide*

## Testing
- `yarn lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_6867001fdf2c832282fba07364e78d3a